### PR TITLE
converted brand header navigation as ember widget

### DIFF
--- a/assets/javascripts/discourse/widgets/brand-header.js.es6
+++ b/assets/javascripts/discourse/widgets/brand-header.js.es6
@@ -3,6 +3,20 @@ import { h } from 'virtual-dom';
 
 const flatten = array => [].concat.apply([], array);
 
+createWidget('nav-links', {
+  tagName: 'nav.links',
+
+  html(attrs) {
+    const links = [].concat(attrs.contents());
+    const liOpts = { };
+
+    const result = [];
+    result.push(h('ul.nav.nav-pills', links.map(l => h('li', liOpts, l))));
+
+    return result;
+  }
+});
+
 export default createWidget('brand-header', {
   tagName: 'header.b-header.clearfix',
   buildKey: () => `header`,
@@ -25,7 +39,7 @@ export default createWidget('brand-header', {
 
     contents.push(this.attach('brand-logo'));
 
-    contents.push(this.attach('menu-links', { contents: () => this.generalLinks() }));
+    contents.push(this.attach('nav-links', { contents: () => this.generalLinks() }));
 
     return h('div.wrap', h('div.contents.clearfix', contents));
   }

--- a/assets/javascripts/discourse/widgets/brand-header.js.es6
+++ b/assets/javascripts/discourse/widgets/brand-header.js.es6
@@ -1,35 +1,22 @@
-import { createWidget } from 'discourse/widgets/widget';
+import { createWidget, applyDecorators } from 'discourse/widgets/widget';
 import DiscourseURL from 'discourse/lib/url';
 import { wantsNewWindow } from 'discourse/lib/intercept-click';
 
 import { h } from 'virtual-dom';
 
-createWidget('brand-menu-item', {
-  tagName: 'li',
+const flatten = array => [].concat.apply([], array);
 
-  html(attrs) {
-    var auto_route = true;
-    if(attrs.external) {
-      auto_route = false;
-    }
-    return h('a', { attributes: { href: attrs.href, 'data-auto-route': auto_route } }, attrs.text);
+generalLinks() {
+  const { siteSettings } = this;
+  const links = [];
+
+  if(siteSettings.brand_home_link_enabled) {
+    links.push({ href: siteSettings.brand_url, className: 'brand-home-link', label: 'brand.home' });
   }
-});
 
-createWidget('brand-navigation', {
-  tagName: 'ul.b-navigation',
-
-  html(attrs) {
-    const menuItems = [];
-
-    if(attrs.brand_home.enabled) {
-      menuItems.push(this.attach('brand-menu-item', { href: attrs.brand_home.url,
-                                                      text: I18n.t('brand.home'),
-                                                      external: true }));
-    }
-    return menuItems;
-  }
-});
+  const extraLinks = flatten(applyDecorators(this, 'generalLinks', this.attrs, this.state));
+  return links.concat(extraLinks).map(l => this.attach('link', l));
+}
 
 export default createWidget('brand-header', {
   tagName: 'header.b-header.clearfix',
@@ -37,11 +24,13 @@ export default createWidget('brand-header', {
 
   html(attrs, state) {
     const { siteSettings } = this;
-    const contents = [ this.attach('brand-logo'),
-                       this.attach('brand-navigation', { brand_home: { enabled: siteSettings.brand_home_link_enabled,
-                                                                       url: siteSettings.brand_url } }) ];
+    const results = [];
 
-    return h('div.wrap', h('div.contents.clearfix', contents));
+    results.push(this.attach('brand-logo'));
+
+    results.push(this.attach('menu-links', { contents: () => this.generalLinks() }));
+
+    return h('div.wrap', h('div.contents.clearfix', { contents: () => results }));
   }
 
 });

--- a/assets/javascripts/discourse/widgets/brand-header.js.es6
+++ b/assets/javascripts/discourse/widgets/brand-header.js.es6
@@ -1,7 +1,4 @@
 import { createWidget, applyDecorators } from 'discourse/widgets/widget';
-import DiscourseURL from 'discourse/lib/url';
-import { wantsNewWindow } from 'discourse/lib/intercept-click';
-
 import { h } from 'virtual-dom';
 
 const flatten = array => [].concat.apply([], array);
@@ -16,7 +13,7 @@ generalLinks() {
 
   const extraLinks = flatten(applyDecorators(this, 'generalLinks', this.attrs, this.state));
   return links.concat(extraLinks).map(l => this.attach('link', l));
-}
+};
 
 export default createWidget('brand-header', {
   tagName: 'header.b-header.clearfix',

--- a/assets/javascripts/discourse/widgets/brand-header.js.es6
+++ b/assets/javascripts/discourse/widgets/brand-header.js.es6
@@ -3,21 +3,21 @@ import { h } from 'virtual-dom';
 
 const flatten = array => [].concat.apply([], array);
 
-generalLinks() {
-  const { siteSettings } = this;
-  const links = [];
-
-  if(siteSettings.brand_home_link_enabled) {
-    links.push({ href: siteSettings.brand_url, className: 'brand-home-link', label: 'brand.home' });
-  }
-
-  const extraLinks = flatten(applyDecorators(this, 'generalLinks', this.attrs, this.state));
-  return links.concat(extraLinks).map(l => this.attach('link', l));
-};
-
 export default createWidget('brand-header', {
   tagName: 'header.b-header.clearfix',
   buildKey: () => `header`,
+
+  generalLinks() {
+    const { siteSettings } = this;
+    const links = [];
+
+    if(siteSettings.brand_home_link_enabled) {
+      links.push({ href: siteSettings.brand_url, className: 'brand-home-link', label: 'brand.home' });
+    }
+
+    const extraLinks = flatten(applyDecorators(this, 'generalLinks', this.attrs, this.state));
+    return links.concat(extraLinks).map(l => this.attach('link', l));
+  },
 
   html(attrs, state) {
     const { siteSettings } = this;

--- a/assets/javascripts/discourse/widgets/brand-header.js.es6
+++ b/assets/javascripts/discourse/widgets/brand-header.js.es6
@@ -21,13 +21,13 @@ export default createWidget('brand-header', {
 
   html(attrs, state) {
     const { siteSettings } = this;
-    const results = [];
+    const contents = [];
 
-    results.push(this.attach('brand-logo'));
+    contents.push(this.attach('brand-logo'));
 
-    results.push(this.attach('menu-links', { contents: () => this.generalLinks() }));
+    contents.push(this.attach('menu-links', { contents: () => this.generalLinks() }));
 
-    return h('div.wrap', h('div.contents.clearfix', { contents: () => results }));
+    return h('div.wrap', h('div.contents.clearfix', contents));
   }
 
 });

--- a/assets/stylesheets/branding.scss
+++ b/assets/stylesheets/branding.scss
@@ -33,27 +33,19 @@
   #brand-text-logo {
     line-height: 32px;
   }
+
+  nav.links {
+    float: left;
+  }
+
+  .nav-pills > li > a {
+    color: scale-color($tertiary, $lightness: 90%);
+    line-height: 24px;
+  }
 }
 
 .d-header {
   margin-top: 48px;
-}
-.b-navigation {
-  float: left;
-  margin: 0;
-}
-.b-navigation li {
-  list-style: none;
-  float: right;
-}
-.b-navigation a {
-  color: scale-color($tertiary, $lightness: 90%);
-  padding: 0 16px;
-  display: inline-block;
-  line-height: 32px;
-  &:hover {
-    color: scale-color($quaternary, $lightness: 50%);
-  }
 }
 #main-outlet {
   padding-top: 130px;

--- a/assets/stylesheets/branding.scss
+++ b/assets/stylesheets/branding.scss
@@ -19,10 +19,10 @@
     float: left;
     margin-right: 24px;
     a {
-      color: scale-color($quaternary, $lightness: 90%);
+      color: scale-color($quaternary, $lightness: 95%);
     }
     &:visited {
-      color: scale-color($quaternary, $lightness: 90%);
+      color: scale-color($quaternary, $lightness: 95%);
     }
   }
 

--- a/assets/stylesheets/branding.scss
+++ b/assets/stylesheets/branding.scss
@@ -19,10 +19,10 @@
     float: left;
     margin-right: 24px;
     a {
-      color: scale-color($quaternary, $lightness: 95%);
+      color: $secondary;
     }
     &:visited {
-      color: scale-color($quaternary, $lightness: 95%);
+      color: $secondary;
     }
   }
 
@@ -38,9 +38,20 @@
     float: left;
   }
 
-  .nav-pills > li > a {
-    color: scale-color($tertiary, $lightness: 90%);
-    line-height: 24px;
+  .nav-pills {
+    margin-bottom: 0;
+    > li > a {
+      color: $secondary;
+      line-height: 22px;
+      &:hover {
+        color: $quaternary;
+        background-color: dark-light-diff($quaternary, $tertiary, 70%, -70%);
+      }
+      &.active > a, > a.active {
+        color: $secondary;
+        background-color: $quaternary;
+      }
+    }
   }
 }
 

--- a/assets/stylesheets/branding.scss
+++ b/assets/stylesheets/branding.scss
@@ -45,7 +45,7 @@
       line-height: 22px;
       &:hover {
         color: $quaternary;
-        background-color: dark-light-diff($quaternary, $tertiary, 70%, -70%);
+        background-color: dark-light-diff($quaternary, $tertiary, -70%, 70%);
       }
       &.active > a, > a.active {
         color: $secondary;


### PR DESCRIPTION
Brand header navigation menu is now a widget named `brand-header:generalLinks` and it also have option to include extraLinks