### PR TITLE
Fix: defaultState() defined twice in brand header

### DIFF
--- a/assets/javascripts/discourse/widgets/brand-header.js.es6
+++ b/assets/javascripts/discourse/widgets/brand-header.js.es6
@@ -64,6 +64,9 @@ export default createWidget('brand-header', {
   defaultState() {
     let states =  {
       hamburgerVisible: false,
+      generalLinks: [],
+      iconLinks: [],
+      loading: true
     };
 
     return states;
@@ -71,10 +74,6 @@ export default createWidget('brand-header', {
 
   toggleHamburger() {
     this.state.hamburgerVisible = !this.state.hamburgerVisible;
-  },
-
-  defaultState() {
-    return { generalLinks: [], iconLinks: [], loading: true};
   },
 
   loadNavigation() {


### PR DESCRIPTION
This was causing the error the error _'Multiple definitions of a property not allowed in strict mode'_ on Internet Explorer 11 and preventing the header from loading at all.